### PR TITLE
add the necessary v to the tag filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,6 @@ workflows:
       - publish:
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)*/
+              only: /v[0-9]+(\.[0-9]+)*/
             branches:
               ignore: /.*/


### PR DESCRIPTION
The releases and tags take the form `v0.0.4` and the publish job tag filter regex needs to match the entirety of the tag in order for the job to fire. 